### PR TITLE
Prevent crashes when scaling a (multi)tool to zero

### DIFF
--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -3,6 +3,8 @@
   "authors": [ "Banane9" ],
   "messages": {
     "CommunityBugFixCollection.Name": "Community Bug-Fix Collection",
-    "CommunityBugFixCollection.Description": "This mod contains fixes for various small Resonite Issues that are still open."
+    "CommunityBugFixCollection.Description": "This mod contains fixes for various small Resonite Issues that are still open.",
+
+    "CommunityBugFixCollection.NoZeroScaleToolRaycast": "Fixes Resonite Issue #98: World crashes when a (multi)tool is scaled to zero."
   }
 }

--- a/CommunityBugFixCollection/NoZeroScaleToolRaycast.cs
+++ b/CommunityBugFixCollection/NoZeroScaleToolRaycast.cs
@@ -1,0 +1,23 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatch(typeof(Tool), nameof(Tool.GetHit))]
+    [HarmonyPatchCategory(nameof(NoZeroScaleToolRaycast))]
+    internal sealed class NoZeroScaleToolRaycast : ResoniteMonkey<NoZeroScaleToolRaycast>
+    {
+        public override bool CanBeDisabled => true;
+
+        private static bool Prepare() => Enabled;
+
+        [HarmonyPrefix]
+        private static bool GetHitPrefix(Tool __instance)
+            => __instance.TipForward.IsValid() && __instance.TipForward != float3.Zero;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ The issues fixed by this mod will be linked in the following list.
 If any of them have been closed and not removed from the mod,
 just disable them in the settings in the meantime.
 
+* World crash when a (multi)tool is scaled to zero (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/98)


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/98