### PR TITLE
Fix ColorX spacing on Protoflux node names

### DIFF
--- a/CommunityBugFixCollection/ColorXNodeNamesSpacing.cs
+++ b/CommunityBugFixCollection/ColorXNodeNamesSpacing.cs
@@ -1,0 +1,21 @@
+﻿using Elements.Core;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(ColorXNodeNamesSpacing))]
+    [HarmonyPatch(typeof(StringHelper), nameof(StringHelper.BeautifyName))]
+    internal sealed class ColorXNodeNamesSpacing : ResoniteMonkey<ColorXNodeNamesSpacing>
+    {
+        public override bool CanBeDisabled => true;
+
+        private static string Postfix(string __result)
+            => __result.Replace("Color X", "ColorX ");
+
+        private static bool Prepare() => Enabled;
+    }
+}


### PR DESCRIPTION
Adds a fix for the ColorX part of https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/496