### PR TITLE
Highlight the selected home world in the inventory

### DIFF
--- a/CommunityBugFixCollection/CommunityBugFixCollection.csproj
+++ b/CommunityBugFixCollection/CommunityBugFixCollection.csproj
@@ -44,5 +44,7 @@
     <PackageReference Include="Resonite.Elements.Quantity" Version="1.2.2" />
     <PackageReference Include="Resonite.FrooxEngine" Version="2024.11.21.479" />
     <PackageReference Include="Resonite.ProtoFluxBindings" Version="2024.13.19.479" />
+    <PackageReference Include="Resonite.SkyFrost.Base" Version="2.1.0" />
+    <PackageReference Include="Resonite.SkyFrost.Base.Models" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/CommunityBugFixCollection/HighlightHomeWorldInInventory.cs
+++ b/CommunityBugFixCollection/HighlightHomeWorldInInventory.cs
@@ -1,0 +1,29 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using SkyFrost.Base;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(HighlightHomeWorldInInventory))]
+    [HarmonyPatch(typeof(InventoryBrowser), nameof(InventoryBrowser.ProcessItem))]
+    internal sealed class HighlightHomeWorldInInventory : ResoniteMonkey<HighlightHomeWorldInInventory>
+    {
+        public override bool CanBeDisabled => true;
+
+        private static void Postfix(InventoryBrowser __instance, InventoryItemUI item)
+        {
+            if (InventoryBrowser.ClassifyItem(item) != InventoryBrowser.SpecialItemType.World
+             || __instance.GetItemWorldUri(item) != __instance.Engine.Cloud.Profile.GetCurrentFavorite(FavoriteEntity.Home))
+                return;
+
+            item.NormalColor.Value = InventoryBrowser.FAVORITE_COLOR;
+            item.SelectedColor.Value = InventoryBrowser.FAVORITE_COLOR.MulRGB(2f);
+        }
+
+        private static bool Prepare() => Enabled;
+    }
+}


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/503