### PR TITLE
Add a ValueProxySource<color> to ValueDisplay<color> visuals

### DIFF
--- a/CommunityBugFixCollection/ColorDisplayValueProxy.cs
+++ b/CommunityBugFixCollection/ColorDisplayValueProxy.cs
@@ -1,0 +1,33 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.ProtoFlux;
+using FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(ColorDisplayValueProxy))]
+    [HarmonyPatch(typeof(ValueDisplay<color>), nameof(ValueDisplay<color>.BuildContentUI))]
+    internal sealed class ColorDisplayValueProxy : ResoniteMonkey<ColorDisplayValueProxy>
+    {
+        public override bool CanBeDisabled => true;
+
+        private static void Postfix(ValueDisplay<color> __instance, ProtoFluxNodeVisual visual)
+        {
+            var colorToColorX = visual.Slot.GetComponentInChildren<ColorToColorX>();
+            var textFormatDriver = visual.Slot.GetComponentInChildren<MultiValueTextFormatDriver>();
+
+            if (colorToColorX is null || textFormatDriver is null)
+                return;
+
+            var valueProxySource = textFormatDriver.Slot.AttachComponent<ValueProxySource<color>>();
+            valueProxySource.Value.DriveFrom(__instance._value.Target);
+        }
+
+        private static bool Prepare() => Enabled;
+    }
+}


### PR DESCRIPTION
Adds fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/557