### PR TITLE
Fix `BrushTool`-derived tools not firing OnDequipped events

### DIFF
--- a/CommunityBugFixCollection/FireBrushToolDequipEvents.cs
+++ b/CommunityBugFixCollection/FireBrushToolDequipEvents.cs
@@ -1,0 +1,29 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(FireBrushToolDequipEvents))]
+    [HarmonyPatch(typeof(BrushTool), nameof(BrushTool.OnDequipped))]
+    internal sealed class FireBrushToolDequipEvents : ResoniteMonkey<FireBrushToolDequipEvents>
+    {
+        public override bool CanBeDisabled => true;
+
+        private static bool Prepare() => Enabled;
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return new[]
+            {
+                CodeInstruction.LoadArgument(0),
+                CodeInstruction.Call((Tool tool) => tool.OnDequipped())
+            }
+            .Concat(instructions);
+        }
+    }
+}


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/723