### PR TITLE
Add a fix for the direct cursor of the InteractionLasers not being scaled independently

### DIFF
--- a/CommunityBugFixCollection/IndependentlyScaleDirectCursor.cs
+++ b/CommunityBugFixCollection/IndependentlyScaleDirectCursor.cs
@@ -1,0 +1,44 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(IndependentlyScaleDirectCursor))]
+    [HarmonyPatch(typeof(InteractionLaser), nameof(InteractionLaser.UpdateLaserVisual))]
+    internal sealed class IndependentlyScaleDirectCursor : ResoniteMonkey<IndependentlyScaleDirectCursor>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static void Postfix(InteractionLaser __instance)
+        {
+            if (!Enabled || !__instance._directCursorActive.Target.Value)
+                return;
+
+            // This is the same calculation as is done for the actual point, but for the direct one
+            var localPoint = __instance._directCursorOffset.Target.Value;
+            var localPointInUserRootPos = __instance.Slot.LocalPointToSpace(in localPoint, __instance.LocalUserRoot.Slot);
+            var userViewInUserRootPos = __instance.LocalUserRoot.Slot.GlobalPointToLocal(__instance.World.LocalUserViewPosition);
+
+            var distanceInUserRoot = MathX.Distance(in localPointInUserRootPos, in userViewInUserRootPos);
+            var localDistance = __instance.Slot.SpaceScaleToLocal(distanceInUserRoot, __instance.LocalUserRoot.Slot);
+
+            var localScaleFactor = !__instance.InputInterface.VR_Active
+                ? localDistance * (__instance.World.LocalUserDesktopFOV / 60f)
+                : 1f + (0.5f * MathX.Max(0f, localDistance - 1f));
+
+            __instance._directCursorRoot.Target.LocalScale = localScaleFactor * float3.One;
+
+            // Have to adjust the direct line to the new scale as well
+            var directLineTargetPos = __instance._directLineMesh.Target.Slot.SpacePointToLocal(__instance._pointSlotPos.Target.Value, __instance.Slot);
+            __instance._directLineTarget.Target.Value = directLineTargetPos;
+            __instance._directCursorVisualsVisible.Value = directLineTargetPos.Magnitude > 0.01f;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ just disable them in the settings in the meantime.
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * Animators updating all associated fields every frame while enabled but not playing (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3480)
+* Direct cursor size becoming very large when snapped to an object much closer than the true cursor (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3654)
 
 
 ## Workarounds


### PR DESCRIPTION
This caused it to become really big and in your face when the laser is sticking to something far away and the direct cursor snaps to something much closer.

This adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3654