### PR TITLE
Fix DuplicateSlot ProtoFlux node crashing game when if OverrideParent is identical to Template

### DIFF
--- a/CommunityBugFixCollection/CheckSelfForDuplicateSlot.cs
+++ b/CommunityBugFixCollection/CheckSelfForDuplicateSlot.cs
@@ -1,0 +1,35 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatch(typeof(Slot), nameof(Slot.Duplicate))]
+    [HarmonyPatchCategory(nameof(CheckSelfForDuplicateSlot))]
+    internal sealed class CheckSelfForDuplicateSlot : ResoniteMonkey<CheckSelfForDuplicateSlot>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var isChildOfMethod = AccessTools.DeclaredMethod(typeof(Slot), nameof(Slot.IsChildOf));
+
+            foreach (var instruction in instructions)
+            {
+                if (instruction.Calls(isChildOfMethod))
+                {
+                    yield return new CodeInstruction(OpCodes.Pop);
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_1);
+                }
+
+                yield return instruction;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ just disable them in the settings in the meantime.
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * Animators updating all associated fields every frame while enabled but not playing (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3480)
 * Direct cursor size becoming very large when snapped to an object much closer than the true cursor (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3654)
+* DuplicateSlot ProtoFlux node crashes game when if OverrideParent is identical to Template (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3950)
 
 
 ## Workarounds


### PR DESCRIPTION

Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3950