### PR TITLE
Make drag and drop copying of components use fixed Slot.DuplicateComponent method

### DIFF
--- a/CommunityBugFixCollection/BreakDragAndDropCopiedComponentDrives.cs
+++ b/CommunityBugFixCollection/BreakDragAndDropCopiedComponentDrives.cs
@@ -1,0 +1,68 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.UIX;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(BreakDragAndDropCopiedComponentDrives))]
+    [HarmonyPatch(typeof(SlotComponentReceiver), nameof(SlotComponentReceiver.TryReceive))]
+    internal sealed class BreakDragAndDropCopiedComponentDrives : ResoniteMonkey<BreakDragAndDropCopiedComponentDrives>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static bool Prefix(SlotComponentReceiver __instance, IEnumerable<IGrabbable> items, Canvas.InteractionData eventData, in float3 globalPoint, out bool __result)
+        {
+            __result = false;
+
+            if (__instance.Target.Target is null)
+                return false;
+
+            foreach (var item in items)
+            {
+                foreach (ReferenceProxy componentsInChild in item.Slot.GetComponentsInChildren<ReferenceProxy>())
+                {
+                    if (componentsInChild.Reference.Target is not Component component || __instance.Target.Target == component.Slot)
+                        continue;
+
+                    __instance.StartTask(async () =>
+                    {
+                        var contextMenu = await __instance.LocalUser.OpenContextMenu(__instance, eventData.source.Slot);
+
+                        var copyItem = contextMenu.AddItem("Inspector.Actions.CopyComponent".AsLocaleKey(), (Uri)null!, RadiantUI_Constants.Hero.GREEN);
+                        var moveItem = contextMenu.AddItem("Inspector.Actions.MoveComponent".AsLocaleKey(), (Uri)null!, RadiantUI_Constants.Hero.PURPLE);
+                        var cancelItem = contextMenu.AddItem("General.Cancel".AsLocaleKey(), (Uri)null!, colorX.White);
+
+                        copyItem.Button.LocalPressed += delegate
+                        {
+                            __instance.Target.Target.DuplicateComponent(component);
+                            __instance.LocalUser.CloseContextMenu(__instance);
+                        };
+
+                        moveItem.Button.LocalPressed += delegate
+                        {
+                            __instance.Target.Target.MoveComponent(component);
+                            __instance.LocalUser.CloseContextMenu(__instance);
+                        };
+
+                        cancelItem.Button.LocalPressed += delegate
+                        {
+                            __instance.LocalUser.CloseContextMenu(__instance);
+                        };
+                    });
+
+                    __result = true;
+                    return false;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ If any of them have been closed and not removed from the mod,
 just disable them in the settings in the meantime.
 
 * Duplicating Components breaking drives (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/92)
+	* Pressing Duplicate on the Component in an Inspector
+	* Using the Component Clone Tool to duplicate them onto a slot
+	* Selecting Copy Component when drag and dropping a Component onto an Inspector
 * Worlds crashing when a (multi)tool is scaled to zero (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/98)
 * Most ProtoFlux nodes in Strings > Constants having invisible names (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/177)
 * The `Remap -1 1 to 0 1` ProtoFlux node having a hard to understand name (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/245)


### PR DESCRIPTION
Fixes the drag and drop copying aspect of https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/92 as well