### PR TITLE
Make selection of custom generics in component selectors case-insensitive

### DIFF
--- a/CommunityBugFixCollection/CaseInsensitiveCustomGenerics.cs
+++ b/CommunityBugFixCollection/CaseInsensitiveCustomGenerics.cs
@@ -1,0 +1,51 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader;
+using MonkeyLoader.Meta;
+using MonkeyLoader.Patching;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+// Taken from ComponentSelectorAdditions
+// https://github.com/ResoniteModdingGroup/ComponentSelectorAdditions
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatch]
+    [HarmonyPatchCategory(nameof(CaseInsensitiveCustomGenerics))]
+    internal sealed class CaseInsensitiveCustomGenerics : Monkey<CaseInsensitiveCustomGenerics>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        protected override bool OnLoaded()
+        {
+            if (!Enabled)
+                return true;
+
+            if (Mod.Loader.Get<Mod>().ById("ComponentSelectorAdditions") is not null)
+            {
+                Logger.Info(() => "Skipping in favor of the ComponentSelectorAdditions fix.");
+                return true;
+            }
+
+            GlobalTypeRegistry._nameToSystemType = new(GlobalTypeRegistry._nameToSystemType, StringComparer.OrdinalIgnoreCase);
+            GlobalTypeRegistry._byName = new(GlobalTypeRegistry._byName, StringComparer.OrdinalIgnoreCase);
+
+            return base.OnLoaded();
+        }
+
+        private static void Postfix(AssemblyTypeRegistry __instance)
+        {
+            __instance._typesByFullName = new(__instance._typesByFullName, StringComparer.OrdinalIgnoreCase);
+            __instance._typesByName.dictionary = new(__instance._typesByName.dictionary, StringComparer.OrdinalIgnoreCase);
+            __instance._movedTypes = new(__instance._movedTypes, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static IEnumerable<MethodBase> TargetMethods()
+            => AccessTools.GetDeclaredConstructors(typeof(AssemblyTypeRegistry), false);
+    }
+}

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -5,6 +5,8 @@
     "CommunityBugFixCollection.Name": "Community Bug-Fix Sammlung",
     "CommunityBugFixCollection.Description": "Diese Mod enthällt Fixes für verschiedene kleine Resonite Issues die noch offen sind.",
 
-    "CommunityBugFixCollection.CopyToClipboard": "In Zwischenablage kopieren"
+    "CommunityBugFixCollection.CopyToClipboard": "In Zwischenablage kopieren",
+
+    "CommunityBugFixCollection.CaseInsensitiveCustomGenerics.Description": "Macht das Auswählen von eigenen generischen Typparametern unabhängig von Groß- und Kleinschreibung."
   }
 }

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -7,6 +7,7 @@
 
     "CommunityBugFixCollection.CopyToClipboard": "Copy to Clipboard",
 
-    "CommunityBugFixCollection.NoZeroScaleToolRaycast": "Fixes Resonite Issue #98: World crashes when a (multi)tool is scaled to zero."
+    "CommunityBugFixCollection.NoZeroScaleToolRaycast": "Fixes Resonite Issue #98: World crashes when a (multi)tool is scaled to zero.",
+    "CommunityBugFixCollection.CaseInsensitiveCustomGenerics.Description": "Makes picking custom generic type parameters case-insensitive."
   }
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ just disable them in the settings in the meantime.
 * The selected Home World in the Inventory not being highlighted as a favorite (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/503)
 * The MaterialGizmo being scaled twice when using Edit on the Material Tool (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/528)
 * The `ValueDisplay<color>` ProtoFluxNode not having a `ValueProxySource<color>` (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/557)
+* Picking custom generic types in Component Selectors not being case-insensitive
+	* https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/620
+	* https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/636
+	* https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4022
 * Tools derived from `BrushTool` not firing *OnDequipped* events (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/723)
 * It not being possible to import multiple audio clips at once (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/737)
 * URLs to text files or Resonite Packages failing to import instead of appearing as a hyperlink (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/785)


### PR DESCRIPTION
Adds a fix for:
 * https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/620
 * https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/636
 * https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4022