### PR TITLE
Prevents Grab World locomotion moving the player when activated

### DIFF
--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -28,6 +28,7 @@
     "CommunityBugFixCollection.NonHDRColorClamping.Description": "Korrigiert, dass die nicht-HDR Varianten der Color(X) Kanal-Additionen die Werte nicht limitieren.",
     "CommunityBugFixCollection.PauseAnimatorUpdates.Description": "Verhindert, dass Animatoren jeden Frame in alle assoziierten Felder schreiben, obwohl sie nicht am animieren sind.",
     "CommunityBugFixCollection.SmoothDraggables.Description": "Umgeht, dass Slider und Joints in Headless-Sessions verrutschen.",
+    "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Verhindert, dass die Welt-Greifen Fortbewegung den Spieler bei jeder Aktivierung bewegt.",
     "CommunityBugFixCollection.UserInspectorAsNonHost.Description": "Sorgt dafür, dass Benutzer-Inspektoren bereits präsente Benutzer auch in Sessions anzeigen, in denen man nicht der Host ist."
   }
 }

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -28,6 +28,7 @@
     "CommunityBugFixCollection.NonHDRColorClamping.Description": "Fixes non-HDR variants of Color(X) channel addition not clamping.",
     "CommunityBugFixCollection.PauseAnimatorUpdates.Description": "Fixes animators updating all associated fields every frame while enabled but not playing.",
     "CommunityBugFixCollection.SmoothDraggables.Description": "Workaround for Sliders and Joints snapping in sessions hosted by a headless.",
+    "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Stops the Grab World Locomotion from moving the player with each activiation.",
     "CommunityBugFixCollection.UserInspectorAsNonHost.Description": "Fixes UserInspectors not listing existing users in the session for non-host users."
   }
 }

--- a/CommunityBugFixCollection/StationaryGrabWorldActivation.cs
+++ b/CommunityBugFixCollection/StationaryGrabWorldActivation.cs
@@ -1,0 +1,35 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+// Originally released under MIT-0 here:
+// https://github.com/art0007i/FixGrabWorld
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(StationaryGrabWorldActivation))]
+    [HarmonyPatch(typeof(GrabWorldLocomotion), nameof(GrabWorldLocomotion.TryActivate))]
+    internal sealed class StationaryGrabWorldActivation : ResoniteMonkey<StationaryGrabWorldActivation>
+    {
+        public override IEnumerable<string> Authors => Contributors.Art0007i;
+
+        public override bool CanBeDisabled => true;
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            var directionReferenceGetter = AccessTools.PropertyGetter(typeof(ILocomotionReference), nameof(ILocomotionReference.DirectionReference));
+
+            foreach (var code in codes)
+            {
+                if (Enabled && code.Calls(directionReferenceGetter))
+                    code.operand = AccessTools.PropertyGetter(typeof(ILocomotionReference), nameof(ILocomotionReference.GripReference));
+
+                yield return code;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The issues fixed by this mod will be linked in the following list.
 If any of them have been closed and not removed from the mod,
 just disable them in the settings in the meantime.
 
+* Grab World Locomotion moving the user forward a little every time it's activated (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/86)
 * Duplicating Components breaking drives (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/92)
 	* Pressing Duplicate on the Component in an Inspector
 	* Using the Component Clone Tool to duplicate them onto a slot


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/86