### PR TITLE
Fix migrated items from messages not spawning

### DIFF
--- a/CommunityBugFixCollection/FixMigratedItemMessages.cs
+++ b/CommunityBugFixCollection/FixMigratedItemMessages.cs
@@ -1,0 +1,30 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using SkyFrost.Base;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+// Originally released under MIT-0 here:
+// https://github.com/art0007i/FixMigratedItemMessages
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(FixMigratedItemMessages))]
+    [HarmonyPatch(typeof(ContactsDialog), nameof(ContactsDialog.SpawnMessageItem))]
+    internal sealed class FixMigratedItemMessages : ResoniteMonkey<FixMigratedItemMessages>
+    {
+        private const string OldPrefix = "neosdb";
+
+        public override IEnumerable<string> Authors => Contributors.Art0007i;
+
+        public override bool CanBeDisabled => true;
+
+        public static void Prefix(ref Record record)
+        {
+            if (Enabled && record.AssetURI.StartsWith(OldPrefix))
+                record.AssetURI = $"{Engine.Current.PlatformProfile.DBScheme}{record.AssetURI[OldPrefix.Length..]}";
+        }
+    }
+}

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -17,6 +17,7 @@
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Verhindert, dass das MaterialGizmo zweimal skaliert wird, wenn man Editieren auf dem Materialwerzeug nutzt.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Verhindert, dass Referenzen zwischen mehreren duplizierten oder zwischen Welten transferierten Objekten gebrochen werden.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Sorgt dafür, dass von BrushTool abgeleitete Werkzeuge OnDequipped Events abschicken.",
+    "CommunityBugFixCollection.FixMigratedItemMessages.Description": "Sorgt dafür, dass migrierte Objekte aus Nachrichten gespawnt werden können, obwohl sie noch auf die alte Platform verweisen.",
     "CommunityBugFixCollection.GammaCorrectedColorXLuminance.Description": "Korrigiert die Berechnung der Luminanz bei nicht-linearen ColorX Farbprofilen.",
     "CommunityBugFixCollection.HighlightHomeWorldInInventory.Description": "Sorgt dafür, dass die ausgewählte Heimatwelt im Inventar korrekt hervorgehoben wird.",
     "CommunityBugFixCollection.ImportMultipleAudioFiles.Description": "Macht es möglich mehrere Audiodateien auf einmal zu importieren.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -17,6 +17,7 @@
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Fixes the MaterialGizmo being scaled twice when using Edit on the Material Tool.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Fixes references between multiple duplicated or transferred-between-worlds items breaking.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Fixes tools derived from BrushTool not firing OnDequipped events.",
+    "CommunityBugFixCollection.FixMigratedItemMessages.Description": "Fixes migrated items sent as messages not spawning because they still point to the old platform.",
     "CommunityBugFixCollection.GammaCorrectedColorXLuminance.Description": "Fixes ColorX Luminance calculations being incorrect for non-linear color profiles.",
     "CommunityBugFixCollection.HighlightHomeWorldInInventory.Description": "Fixes the selected Home World in the Inventory not being highlighted as a favorite.",
     "CommunityBugFixCollection.ImportMultipleAudioFiles.Description": "Fixes it not being possible to import multiple audio clips at once.",

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The issues fixed by this mod will be linked in the following list.
 If any of them have been closed and not removed from the mod,
 just disable them in the settings in the meantime.
 
+* Migrated items sent as messages do not spawn because they still point to `neosdb` (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/83)
 * Grab World Locomotion moving the user forward a little every time it's activated (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/86)
 * Duplicating Components breaking drives (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/92)
 	* Pressing Duplicate on the Component in an Inspector


### PR DESCRIPTION
This was because they still point to the old platform

Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/83