### PR TITLE
Fix grid world template crashing

### DIFF
--- a/CommunityBugFixCollection/BetterGridWorldPreset.cs
+++ b/CommunityBugFixCollection/BetterGridWorldPreset.cs
@@ -54,7 +54,9 @@ namespace CommunityBugFixCollection
             attachedModel.material.Smoothness.Value = 0f;
 
             var boxCollider = ground.AttachComponent<BoxCollider>();
-            boxCollider.Size.DriveFrom(attachedModel.mesh.Size);
+            var swizzle = ground.AttachComponent<Float2ToFloat3SwizzleDriver>();
+            swizzle.Source.Target = attachedModel.mesh.Size;
+            swizzle.Target.Target = boxCollider.Size;
             boxCollider.SetCharacterCollider();
 
             return false;


### PR DESCRIPTION
https://discord.com/channels/901126079857692714/1365170008165978117

Please test code in the future (I know this is partially on me because I approved the PR)
```
Unhandled Exception when updating world: . State Running, Refresh Stage: RefreshBegin, Init State: Finished, SyncTick 1, StateVersion: 2
System.Exception: Target and source types must match! Source: Elements.Core.float2, Target: Elements.Core.float3
   at void FrooxEngine.ValueCopyExtensions.DriveFrom(IField field, IField source, bool writeBack, bool keepOriginalValue, bool searchForDuplicate)
   at bool CommunityBugFixCollection.BetterGridWorldPreset.Prefix(World w)
   at bool FrooxEngine.World.RefreshStep()
   at bool FrooxEngine.World.Refresh()
   at void FrooxEngine.WorldManager.UpdateStep()
```