### PR TITLE
Correct ProtoFlux value casts of bytes to other values

### DIFF
--- a/CommunityBugFixCollection/CommunityBugFixCollection.csproj
+++ b/CommunityBugFixCollection/CommunityBugFixCollection.csproj
@@ -44,6 +44,8 @@
     <PackageReference Include="Resonite.Elements.Quantity" Version="1.2.3" />
     <PackageReference Include="Resonite.FrooxEngine" Version="2025.3.21.23" />
     <PackageReference Include="Resonite.FrooxEngine.Store" Version="1.0.3" />
+    <PackageReference Include="Resonite.ProtoFlux.Core" Version="1.2.0" />
+    <PackageReference Include="Resonite.ProtoFlux.Nodes.Core" Version="1.2.0" />
     <PackageReference Include="Resonite.ProtoFluxBindings" Version="2025.5.18.24" />
     <PackageReference Include="Resonite.SkyFrost.Base" Version="2.1.0" />
     <PackageReference Include="Resonite.SkyFrost.Base.Models" Version="2.1.0" />

--- a/CommunityBugFixCollection/CorrectByteCasting.cs
+++ b/CommunityBugFixCollection/CorrectByteCasting.cs
@@ -1,0 +1,48 @@
+﻿using HarmonyLib;
+using MonkeyLoader.Resonite;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using ProtoFlux.Runtimes.Execution.Nodes.Casts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    internal sealed class CorrectByteCasting : ResoniteMonkey<CorrectByteCasting>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        protected override bool OnEngineReady()
+        {
+            var targets = AccessTools.GetTypesFromAssembly(typeof(Cast_byte_To_int).Assembly)
+                .Select(type => (Type: type, ValueCast: type.GetCustomAttribute<ValueCastAttribute>()))
+                .Where(candidate => candidate.ValueCast?.From == typeof(byte))
+                .Select(candidate => (candidate.ValueCast, Method: AccessTools.DeclaredMethod(candidate.Type, nameof(Cast_byte_To_int.Compute))))
+                .Where(target => target.Method is not null);
+
+            var computePrefix = AccessTools.DeclaredMethod(typeof(CorrectByteCasting), nameof(ComputePrefix));
+
+            foreach (var target in targets)
+                Harmony.Patch(target.Method, computePrefix.MakeGenericMethod(target.ValueCast.To));
+
+            return true;
+        }
+
+        private static bool ComputePrefix<T>(ExecutionContext context, ref T __result)
+            where T : unmanaged
+        {
+            if (!Enabled)
+                return true;
+
+            var value = (object)0.ReadValue<byte>(context);
+            __result = (T)(Convert.ChangeType(value, typeof(T)) ?? default(T));
+
+            return false;
+        }
+    }
+}

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -16,6 +16,7 @@
     "CommunityBugFixCollection.ColorDisplayValueProxy.Description": "Sorgt dafür, dass ValueDisplay<color> Nodes eine ValueProxySource Komponente haben.",
     "CommunityBugFixCollection.ColorXNodeNamesSpacing.Description": "Korrigiert die Schreibweise der Namen von ProtoFlux Nodes die ColorX enthalten.",
     "CommunityBugFixCollection.CopySyncMemberToClipboardAction.Description": "Fügt eine Kopieren Aktion zu Feldern in Inspektoren hinzu, die keine Referenzen sind.",
+    "CommunityBugFixCollection.CorrectByteCasting.Description": "Korrigiert die Konvertierung von bytes in andere Werte mittels ProtoFlux Value Casts.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Verhindert, dass das MaterialGizmo zweimal skaliert wird, wenn man Editieren auf dem Materialwerzeug nutzt.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Verhindert, dass Referenzen zwischen mehreren duplizierten oder zwischen Welten transferierten Objekten gebrochen werden.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Sorgt dafür, dass von BrushTool abgeleitete Werkzeuge OnDequipped Events abschicken.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -16,6 +16,7 @@
     "CommunityBugFixCollection.ColorDisplayValueProxy.Description": "Fixes ValueDisplay<color> not having a ValueProxySource component.",
     "CommunityBugFixCollection.ColorXNodeNamesSpacing.Description": "Fixes ProtoFlux node names containing ColorX being spaced wrong.",
     "CommunityBugFixCollection.CopySyncMemberToClipboardAction.Description": "Adds Copy to Clipboard action on any non-reference member fields in Inspectors.",
+    "CommunityBugFixCollection.CorrectByteCasting.Description": "Fixes ProtoFlux value casts from byte to some other value converting incorrectly.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Fixes the MaterialGizmo being scaled twice when using Edit on the Material Tool.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Fixes references between multiple duplicated or transferred-between-worlds items breaking.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Fixes tools derived from BrushTool not firing OnDequipped events.",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ just disable them in the settings in the meantime.
 * URLs to text files or Resonite Packages failing to import instead of appearing as a hyperlink (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/785)
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
+* ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)
 * Grid World grid being off-center (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2754)
 * Animators updating all associated fields every frame while enabled but not playing (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3480)
 * Direct cursor size becoming very large when snapped to an object much closer than the true cursor (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3654)


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257