### PR TITLE
ValueMod Decimal fix added

### DIFF
--- a/CommunityBugFixCollection/Contributors.cs
+++ b/CommunityBugFixCollection/Contributors.cs
@@ -16,5 +16,7 @@ namespace CommunityBugFixCollection
         public static string[] LeCloutPanda { get; } = ["LeCloutPanda"];
 
         public static string[] Nytra { get; } = ["Nytra"];
+
+        public static string[] __Choco__ { get; } = ["__Choco__"];
     }
 }

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -34,6 +34,7 @@
     "CommunityBugFixCollection.PauseAnimatorUpdates.Description": "Fixes animators updating all associated fields every frame while enabled but not playing.",
     "CommunityBugFixCollection.SmoothDraggables.Description": "Workaround for Sliders and Joints snapping in sessions hosted by a headless.",
     "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Stops the Grab World Locomotion from moving the player with each activiation.",
-    "CommunityBugFixCollection.UserInspectorAsNonHost.Description": "Fixes UserInspectors not listing existing users in the session for non-host users."
+    "CommunityBugFixCollection.UserInspectorAsNonHost.Description": "Fixes UserInspectors not listing existing users in the session for non-host users.",
+    "CommunityBugFixCollection.ValueModDecimal.Description": "Adds a zero check to the Decimal ValueMod ProtoFlux node to prevent DIV/0 crashes"
   }
 }

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -1,6 +1,6 @@
 {
   "localeCode": "en",
-  "authors": [ "Banane9" ],
+  "authors": [ "Banane9", "__Choco__" ],
   "messages": {
     "CommunityBugFixCollection.Name": "Community Bug-Fix Collection",
     "CommunityBugFixCollection.Description": "This mod contains fixes for various small Resonite Issues that are still open.",

--- a/CommunityBugFixCollection/ValueModDecimal.cs
+++ b/CommunityBugFixCollection/ValueModDecimal.cs
@@ -16,7 +16,7 @@ namespace CommunityBugFixCollection
 
         public override bool CanBeDisabled => true;
 
-        private static bool VarDecMod(Decimal a, Decimal b)
+        private static bool Prefix(Decimal a, Decimal b)
         {
             if (b == 0)
             {

--- a/CommunityBugFixCollection/ValueModDecimal.cs
+++ b/CommunityBugFixCollection/ValueModDecimal.cs
@@ -16,13 +16,6 @@ namespace CommunityBugFixCollection
 
         public override bool CanBeDisabled => true;
 
-        private static bool Prefix(Decimal a, Decimal b)
-        {
-            if (b == 0)
-            {
-                return false;
-            }
-            return true;
-        }
+        private static bool Prefix(Decimal a, Decimal b) => !Enabled || b != 0;
     }
 }

--- a/CommunityBugFixCollection/ValueModDecimal.cs
+++ b/CommunityBugFixCollection/ValueModDecimal.cs
@@ -1,0 +1,28 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(ValueModDecimal))]
+    [HarmonyPatch(typeof(Elements.Core.Coder<Decimal>), nameof(Elements.Core.Coder<Decimal>.Mod))]
+    internal sealed class ValueModDecimal : ResoniteMonkey<ValueModDecimal>
+    {
+        public override IEnumerable<string> Authors => Contributors.__Choco__;
+
+        public override bool CanBeDisabled => true;
+
+        private static bool VarDecMod(Decimal a, Decimal b)
+        {
+            if (b == 0)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ just disable them in the settings in the meantime.
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)
+* ValueMod<Decimal> node crashes the game when B input is set to zero or disconnected. (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2746)
 * Grid World grid being off-center (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2754)
 * Animators updating all associated fields every frame while enabled but not playing (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3480)
 * Direct cursor size becoming very large when snapped to an object much closer than the true cursor (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3654)
 * Grid World floor shaking on AMD and Intel GPUs (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3829)
 * DuplicateSlot ProtoFlux node crashes game when if OverrideParent is identical to Template (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3950)
-* ValueMod<Decimal> node crashes the game when B input is set to zero or disconnected. (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2746)
 
 Fixes with no issue (that could be found).
 * Content of notification being off-center.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ just disable them in the settings in the meantime.
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)
-* ValueMod<Decimal> node crashes the game when B input is set to zero or disconnected. (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2746)
+* `ValueMod<Decimal>` node crashes the game when B input is set to zero or disconnected. (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2746)
 * Grid World grid being off-center (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2754)
 * Animators updating all associated fields every frame while enabled but not playing (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3480)
 * Direct cursor size becoming very large when snapped to an object much closer than the true cursor (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3654)


### PR DESCRIPTION
ValueMod Decimal fix added.

Prevents a crash when the B input of the ValueMod\<Decimal\> node is set to zero or disconnected, https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2746