### PR TITLE
Make the context menu stay a fixed on-screen size in desktop mode, regardless of FOV

### DIFF
--- a/CommunityBugFixCollection/ConsistentContextMenuAngularSize.cs
+++ b/CommunityBugFixCollection/ConsistentContextMenuAngularSize.cs
@@ -1,0 +1,49 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(ConsistentContextMenuAngularSize))]
+    [HarmonyPatch(typeof(ContextMenu), nameof(ContextMenu.OnCommonUpdate))]
+    internal sealed class ConsistentContextMenuAngularSize : ResoniteMonkey<ConsistentContextMenuAngularSize>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static void Postfix(ContextMenu __instance)
+        {
+            if (!Enabled || !__instance.IsUnderLocalUser)
+                return;
+
+            // Vanilla value for the magic constant
+            var magicConstant = 0.2f;
+
+            if (!__instance.LocalUser.VR_Active)
+            {
+                // This whole equation is based on a FOV of 60° as the default
+                // The formula for the angular diameter of a plane is: a = 2 * atan(size / (2 * distance))
+                // Invert to: tan(0.5 * a) and multiply with magic 0.34641 to get the vanilla value of 0.2 for 60°
+                // Calculation of magic multiplier: https://www.wolframalpha.com/input?i2d=true&i=0.2+%3D+x*+Tan%5BDivide%5B%CF%80%2C180%5D+*.5+*+60+rad%5D
+                // Graph of resulting magic constant replacement: https://www.wolframalpha.com/input?i2d=true&i=0.34641+*+Tan%5BDivide%5B%CF%80%2C180%5D*.5*x+rad%5D+for+10+%3C%3D+x+%3C%3D+120
+
+                var fov = __instance.World.GetFOV();
+                magicConstant = 0.34641f * MathX.Tan(MathX.Deg2Rad * 0.5f * fov);
+            }
+
+            var scale = float3.One * (magicConstant / __instance.Canvas.Size.Value.y);
+
+            // Only update when scale is different from current -
+            // ideally this would use a local field on the ContextMenu to check for the FOV changing.
+            // Can't do a static value here because there's multiple ContextMenus, even for the local user,
+            // and using a ConditionalWeakTable would be more overhead than it's worth.
+            if ((MathX.Abs(scale - __instance.Canvas.Slot.LocalScale) > (0.000001f * float3.One)).Any())
+                __instance.Canvas.Slot.LocalScale = scale;
+        }
+    }
+}

--- a/CommunityBugFixCollection/ConsistentContextMenuAngularSize.cs
+++ b/CommunityBugFixCollection/ConsistentContextMenuAngularSize.cs
@@ -18,7 +18,7 @@ namespace CommunityBugFixCollection
 
         private static void Postfix(ContextMenu __instance)
         {
-            if (!Enabled || !__instance.IsUnderLocalUser)
+            if (!Enabled || !__instance.IsVisible || !__instance.IsUnderLocalUser)
                 return;
 
             // Vanilla value for the magic constant

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -14,6 +14,7 @@
     "CommunityBugFixCollection.CheckSelfForDuplicateSlot.Description": "Verhindert einen Crash wenn der OverrideParent bei der Duplicate Slot ProtoFlux Node gleich dem Template ist.",
     "CommunityBugFixCollection.ColorDisplayValueProxy.Description": "Sorgt dafür, dass ValueDisplay<color> Nodes eine ValueProxySource Komponente haben.",
     "CommunityBugFixCollection.ColorXNodeNamesSpacing.Description": "Korrigiert die Schreibweise der Namen von ProtoFlux Nodes die ColorX enthalten.",
+    "CommunityBugFixCollection.ConsistentContextMenuAngularSize.Description": "Sorgt dafür, dass das Kontextmenü im Desktopmodus immer die gleiche Größe auf dem Bildschirm hat, unabhängig vom Sichtfeld (FOV).",
     "CommunityBugFixCollection.CopySyncMemberToClipboardAction.Description": "Fügt eine Kopieren Aktion zu Feldern in Inspektoren hinzu, die keine Referenzen sind.",
     "CommunityBugFixCollection.CorrectByteCasting.Description": "Korrigiert die Konvertierung von bytes in andere Werte mittels ProtoFlux Value Casts.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Verhindert, dass das MaterialGizmo zweimal skaliert wird, wenn man Editieren auf dem Materialwerzeug nutzt.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -14,6 +14,7 @@
     "CommunityBugFixCollection.CheckSelfForDuplicateSlot.Description": "Fixes a crash when the OverrideParent of the Duplicate Slot ProtoFlux node is identical to the Template.",
     "CommunityBugFixCollection.ColorDisplayValueProxy.Description": "Fixes ValueDisplay<color> not having a ValueProxySource component.",
     "CommunityBugFixCollection.ColorXNodeNamesSpacing.Description": "Fixes ProtoFlux node names containing ColorX being spaced wrong.",
+    "CommunityBugFixCollection.ConsistentContextMenuAngularSize.Description": "Makes the context menu stay a fixed on-screen size in desktop mode, regardless of FOV.",
     "CommunityBugFixCollection.CopySyncMemberToClipboardAction.Description": "Adds Copy to Clipboard action on any non-reference member fields in Inspectors.",
     "CommunityBugFixCollection.CorrectByteCasting.Description": "Fixes ProtoFlux value casts from byte to some other value converting incorrectly.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Fixes the MaterialGizmo being scaled twice when using Edit on the Material Tool.",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ just disable them in the settings in the meantime.
 * It not being possible to import multiple audio clips at once (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/737)
 * URLs to text files or Resonite Packages failing to import instead of appearing as a hyperlink (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/785)
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
+* Context Menu changing size and becoming unusable with extreme FOVs (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/991)
 * ColorX From HexCode (ProtoFlux node) defaults to Linear profile (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1404)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/991