### PR TITLE
Let failed world load indicator stay for at least 20 seconds

### DIFF
--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -28,6 +28,7 @@
     "CommunityBugFixCollection.ImportMultipleAudioFiles.Description": "Macht es möglich mehrere Audiodateien auf einmal zu importieren.",
     "CommunityBugFixCollection.ImportWebFilesAsUrls.Description": "Sorgt dafür, dass URLs zu Textdateien oder Resonite Packages nicht importiert werden, statt als Hyperlink aufzutauchen.",
     "CommunityBugFixCollection.IndependentlyScaleDirectCursor.Description": "Verhindert, dass der direkte Cursor sehr groß wird, wenn er an einem deutlich nährem Objekt hängt als der echte Cursor.",
+    "CommunityBugFixCollection.LongerWorldLoadingFailIndication.Description": "Lässt den Welt-Ladefortschritts-Indikator frühestens nach 20s verschwinden, falls der Vorgang fehlgeschlagen ist.",
     "CommunityBugFixCollection.NoLossOfColorProfile.Description": "Verhindert, dass Farbprofile nicht bei allen Berechnungen erhalten bleiben.",
     "CommunityBugFixCollection.NoZeroScaleToolRaycast.Description": "Verhinder einen Crash wenn (Multi-)Werkzeuge auf null skaliert werden.",
     "CommunityBugFixCollection.NodeNameAdjustments.Description": "Korrigiert, dass die Namen der meisten ProtoFlux Nodes in Strings > Constants unsichtbar sind.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -28,6 +28,7 @@
     "CommunityBugFixCollection.ImportMultipleAudioFiles.Description": "Fixes it not being possible to import multiple audio clips at once.",
     "CommunityBugFixCollection.ImportWebFilesAsUrls.Description": "Fixes URLs to text files or Resonite Packages failing to import instead of appearing as a hyperlink.",
     "CommunityBugFixCollection.IndependentlyScaleDirectCursor.Description": "Fixes direct cursor size becoming very large when snapped to an object much closer than the true cursor.",
+    "CommunityBugFixCollection.LongerWorldLoadingFailIndication.Description": "Only lets the World Load Progress Indicator disappear after 20s or more if the process failed.",
     "CommunityBugFixCollection.NoLossOfColorProfile.Description": "Fixes Color Profile not being preserved on all operations.",
     "CommunityBugFixCollection.NoZeroScaleToolRaycast.Description": "Fixes a crash when a (multi)tool is scaled to zero.",
     "CommunityBugFixCollection.NodeNameAdjustments.Description": "Fixes most ProtoFlux nodes in Strings > Constants having invisible names.",

--- a/CommunityBugFixCollection/LongerWorldLoadingFailIndication.cs
+++ b/CommunityBugFixCollection/LongerWorldLoadingFailIndication.cs
@@ -1,0 +1,39 @@
+﻿using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(LongerWorldLoadingFailIndication))]
+    [HarmonyPatch(typeof(WorldLoadProgress), nameof(WorldLoadProgress.OnCommonUpdate))]
+    internal sealed class LongerWorldLoadingFailIndication : ResoniteMonkey<LongerWorldLoadingFailIndication>
+    {
+        private static float _vanillaDelay = 5f;
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static float GetDestroyDelay()
+            => Enabled ? Math.Max(20f, _vanillaDelay) : _vanillaDelay;
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codeInstructions)
+        {
+            var instructions = new List<CodeInstruction>(codeInstructions);
+
+            var getDestroyDelayMethod = AccessTools.DeclaredMethod(typeof(LongerWorldLoadingFailIndication), nameof(GetDestroyDelay));
+            var runInSecondsMethod = AccessTools.DeclaredMethod(typeof(ComponentBase<Component>), nameof(ComponentBase<Component>.RunInSeconds));
+
+            var runInSecondsIndex = instructions.FindIndex(instruction => instruction.Calls(runInSecondsMethod));
+            var loadDelayIndex = instructions.FindLastIndex(runInSecondsIndex, instruction => instruction.opcode == OpCodes.Ldc_R4);
+
+            _vanillaDelay = (float)instructions[loadDelayIndex].operand;
+            instructions[loadDelayIndex] = new CodeInstruction(OpCodes.Call, getDestroyDelayMethod);
+
+            return instructions;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ just disable them in the settings in the meantime.
 * The NoDestroyUndo component not preventing undoing the destruction of something (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/979)
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * Context Menu changing size and becoming unusable with extreme FOVs (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/991)
+* World Load Progress Indicator disappearing too quickly on fail (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1019)
 * Context Menu label outline not fading out like everything else (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1027)
 * ColorX From HexCode (ProtoFlux node) defaults to Linear profile (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1404)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1019

I didn't get to properly test this, but it patches fine, so I don't see why it wouldn't work :'D