### PR TITLE
Allow Hyperlink components to open URLs with any scheme, not just http(s)

### DIFF
--- a/CommunityBugFixCollection/AnyProtocolHyperlinks.cs
+++ b/CommunityBugFixCollection/AnyProtocolHyperlinks.cs
@@ -1,0 +1,66 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatch]
+    [HarmonyPatchCategory(nameof(AnyProtocolHyperlinks))]
+    internal sealed class AnyProtocolHyperlinks : ResoniteMonkey<AnyProtocolHyperlinks>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(HyperlinkOpenDialog), nameof(HyperlinkOpenDialog.Open))]
+        private static bool HyperlinkOpenDialogOpenPrefix(HyperlinkOpenDialog __instance)
+        {
+            if (!Enabled)
+                return true;
+
+            if (__instance.World != Userspace.UserspaceWorld || __instance.URL.Value is null)
+                return false;
+
+            Logger.Debug(() => $"Opening Hyperlink: {__instance.URL.Value}");
+            __instance.RunInBackground(() => Process.Start(__instance.URL.Value.ToString()));
+
+            __instance.Slot.Destroy();
+
+            return false;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(Hyperlink), nameof(Hyperlink.Open))]
+        private static bool HyperlinkOpenPostfix(bool __result, Hyperlink __instance)
+        {
+            if (!Enabled)
+                return __result;
+
+            if (__result)
+                return true;
+
+            var url = __instance.URL.Value;
+            if (url is null || (__instance.OpenOnce.Value && url == __instance._lastOpened))
+                return false;
+
+            __instance._lastOpened = url;
+
+            Userspace.UserspaceWorld.RunSynchronously(delegate
+            {
+                Slot slot = Userspace.UserspaceWorld.AddSlot("Hyperlink");
+                slot.PositionInFrontOfUser(float3.Backward);
+                slot.AttachComponent<HyperlinkOpenDialog>().Setup(url, __instance.Reason.Value);
+            });
+
+            __instance.RunInSeconds(5f, () => __instance._lastOpened = null!);
+
+            return true;
+        }
+    }
+}

--- a/CommunityBugFixCollection/AnyProtocolHyperlinks.cs
+++ b/CommunityBugFixCollection/AnyProtocolHyperlinks.cs
@@ -24,11 +24,14 @@ namespace CommunityBugFixCollection
             if (!Enabled)
                 return true;
 
-            if (__instance.World != Userspace.UserspaceWorld || __instance.URL.Value is null)
+            if (__instance.World != Userspace.UserspaceWorld)
                 return false;
 
-            Logger.Debug(() => $"Opening Hyperlink: {__instance.URL.Value}");
-            __instance.RunInBackground(() => Process.Start(__instance.URL.Value.ToString()));
+            if (__instance.URL.Value is not null)
+            {
+                Logger.Debug(() => $"Opening Hyperlink: {__instance.URL.Value}");
+                __instance.RunInBackground(() => Process.Start(__instance.URL.Value.ToString()));
+            }
 
             __instance.Slot.Destroy();
 

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -7,6 +7,7 @@
 
     "CommunityBugFixCollection.CopyToClipboard": "In Zwischenablage kopieren",
 
+    "CommunityBugFixCollection.AnyProtocolHyperlinks.Description": "Erlaubt es Hyperlink-Komponenten URLs mit beliebigen Schemata zu öffnen, statt nur http(s).",
     "CommunityBugFixCollection.BetterGridWorldPreset.Description": "Verbessert das Grid Welt Preset indem das zittern des Bodens verhindert und das Grid zentriert wird.",
     "CommunityBugFixCollection.BreakDragAndDropCopiedComponentDrives.Description": "Sorgt dafür, dass Drives beim Kopieren von Komponenten mittels Drag-und-Drop nicht kaputt gehen.",
     "CommunityBugFixCollection.CaseInsensitiveCustomGenerics.Description": "Macht das Auswählen von eigenen generischen Typparametern unabhängig von Groß- und Kleinschreibung.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -7,6 +7,7 @@
 
     "CommunityBugFixCollection.CopyToClipboard": "Copy to Clipboard",
 
+    "CommunityBugFixCollection.AnyProtocolHyperlinks.Description": "Allows Hyperlink components to open URLs with any scheme, not just http(s).",
     "CommunityBugFixCollection.BetterGridWorldPreset.Description": "Improves the Grid World Preset by preventing the shaking ground and centering the grid.",
     "CommunityBugFixCollection.BreakDragAndDropCopiedComponentDrives.Description": "Fixes copying components using drag-and-drop breaking drives.",
     "CommunityBugFixCollection.CaseInsensitiveCustomGenerics.Description": "Makes picking custom generic type parameters case-insensitive.",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ just disable them in the settings in the meantime.
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * Context Menu changing size and becoming unusable with extreme FOVs (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/991)
 * World Load Progress Indicator disappearing too quickly on fail (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1019)
+* Hyperlink components only opening http(s) links (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1018)
 * Context Menu label outline not fading out like everything else (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1027)
 * ColorX From HexCode (ProtoFlux node) defaults to Linear profile (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1404)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1018