### PR TITLE
Make the outlines of the labels of the context menu fade out like the rest of it

### DIFF
--- a/CommunityBugFixCollection/FadeContextMenuLabelOutlines.cs
+++ b/CommunityBugFixCollection/FadeContextMenuLabelOutlines.cs
@@ -1,0 +1,38 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.FrooxEngine.ProtoFlux.CoreNodes;
+using FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Color;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(FadeContextMenuLabelOutlines))]
+    [HarmonyPatch(typeof(ContextMenu), nameof(ContextMenu.OnAttach))]
+    internal sealed class FadeContextMenuLabelOutlines : ResoniteMonkey<FadeContextMenuLabelOutlines>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static void Postfix(ContextMenu __instance)
+        {
+            var slot = __instance.Slot;
+
+            // Create protoflux to drive the font materials's OutlineColor in sync with the (white) fade's alpha
+
+            var source = slot.AttachComponent<ValueSource<colorX>>();
+            source.TrySetRootSource(__instance._fillFade.Target);
+
+            var setAlpha = slot.AttachComponent<ColorXSetValue>();
+            setAlpha.Color.Target = source;
+
+            var drive = slot.AttachComponent<ValueFieldDrive<colorX>>();
+            drive.Value.Target = setAlpha;
+            drive.TrySetRootTarget(__instance._fontMaterial.Target.OutlineColor);
+        }
+    }
+}

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -19,6 +19,7 @@
     "CommunityBugFixCollection.CorrectByteCasting.Description": "Korrigiert die Konvertierung von bytes in andere Werte mittels ProtoFlux Value Casts.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Verhindert, dass das MaterialGizmo zweimal skaliert wird, wenn man Editieren auf dem Materialwerzeug nutzt.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Verhindert, dass Referenzen zwischen mehreren duplizierten oder zwischen Welten transferierten Objekten gebrochen werden.",
+    "CommunityBugFixCollection.FadeContextMenuLabelOutlines.Description": "Sorgt dafür, dass die Umrandungen der Beschriftungen im Kontextmenü genauso verblassen wie der Rest davon.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Sorgt dafür, dass von BrushTool abgeleitete Werkzeuge OnDequipped Events abschicken.",
     "CommunityBugFixCollection.FixMigratedItemMessages.Description": "Sorgt dafür, dass migrierte Objekte aus Nachrichten gespawnt werden können, obwohl sie noch auf die alte Platform verweisen.",
     "CommunityBugFixCollection.GammaCorrectedColorXLuminance.Description": "Korrigiert die Berechnung der Luminanz bei nicht-linearen ColorX Farbprofilen.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -19,6 +19,7 @@
     "CommunityBugFixCollection.CorrectByteCasting.Description": "Fixes ProtoFlux value casts from byte to some other value converting incorrectly.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Fixes the MaterialGizmo being scaled twice when using Edit on the Material Tool.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Fixes references between multiple duplicated or transferred-between-worlds items breaking.",
+    "CommunityBugFixCollection.FadeContextMenuLabelOutlines.Description": "Makes the outlines of the labels of the context menu fade out like the rest of it.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Fixes tools derived from BrushTool not firing OnDequipped events.",
     "CommunityBugFixCollection.FixMigratedItemMessages.Description": "Fixes migrated items sent as messages not spawning because they still point to the old platform.",
     "CommunityBugFixCollection.GammaCorrectedColorXLuminance.Description": "Fixes ColorX Luminance calculations being incorrect for non-linear color profiles.",

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ just disable them in the settings in the meantime.
 * URLs to text files or Resonite Packages failing to import instead of appearing as a hyperlink (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/785)
 * References in multiple duplicated or transferred-between-worlds items breaking (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/984)
 * Context Menu changing size and becoming unusable with extreme FOVs (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/991)
+* Context Menu label outline not fading out like everything else (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1027)
 * ColorX From HexCode (ProtoFlux node) defaults to Linear profile (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1404)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)


### PR DESCRIPTION

Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1027