### PR TITLE
Correct the spelling of Overridden on ProtoFlux nodes

### DIFF
--- a/CommunityBugFixCollection/CorrectOverriddenSpelling.cs
+++ b/CommunityBugFixCollection/CorrectOverriddenSpelling.cs
@@ -1,0 +1,26 @@
+﻿using Elements.Core;
+using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(CorrectOverriddenSpelling))]
+    [HarmonyPatch(typeof(StringHelper), nameof(StringHelper.BeautifyName))]
+    internal sealed class CorrectOverriddenSpelling : ResoniteMonkey<CorrectOverriddenSpelling>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static string Postfix(string __result)
+        {
+            if (!Enabled)
+                return __result;
+
+            return __result.Replace("Overriden", "Overridden");
+        }
+    }
+}

--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -19,6 +19,7 @@
     "CommunityBugFixCollection.CopySyncMemberToClipboardAction.Description": "Fügt eine Kopieren Aktion zu Feldern in Inspektoren hinzu, die keine Referenzen sind.",
     "CommunityBugFixCollection.CorrectByteCasting.Description": "Korrigiert die Konvertierung von bytes in andere Werte mittels ProtoFlux Value Casts.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Verhindert, dass das MaterialGizmo zweimal skaliert wird, wenn man Editieren auf dem Materialwerzeug nutzt.",
+    "CommunityBugFixCollection.CorrectOverriddenSpelling.Description": "Korrigiert die Schreibweise von Overridden auf ProtoFlux Nodes.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Verhindert, dass Referenzen zwischen mehreren duplizierten oder zwischen Welten transferierten Objekten gebrochen werden.",
     "CommunityBugFixCollection.FadeContextMenuLabelOutlines.Description": "Sorgt dafür, dass die Umrandungen der Beschriftungen im Kontextmenü genauso verblassen wie der Rest davon.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Sorgt dafür, dass von BrushTool abgeleitete Werkzeuge OnDequipped Events abschicken.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -19,6 +19,7 @@
     "CommunityBugFixCollection.CopySyncMemberToClipboardAction.Description": "Adds Copy to Clipboard action on any non-reference member fields in Inspectors.",
     "CommunityBugFixCollection.CorrectByteCasting.Description": "Fixes ProtoFlux value casts from byte to some other value converting incorrectly.",
     "CommunityBugFixCollection.CorrectMaterialGizmoScaling.Description": "Fixes the MaterialGizmo being scaled twice when using Edit on the Material Tool.",
+    "CommunityBugFixCollection.CorrectOverriddenSpelling.Description": "Corrects the spelling of Overridden on ProtoFlux nodes.",
     "CommunityBugFixCollection.DuplicateAndMoveMultipleGrabbedItems.Description": "Fixes references between multiple duplicated or transferred-between-worlds items breaking.",
     "CommunityBugFixCollection.FadeContextMenuLabelOutlines.Description": "Makes the outlines of the labels of the context menu fade out like the rest of it.",
     "CommunityBugFixCollection.FireBrushToolDequipEvents.Description": "Fixes tools derived from BrushTool not firing OnDequipped events.",

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ just disable them in the settings in the meantime.
 * World Load Progress Indicator disappearing too quickly on fail (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1019)
 * Context Menu label outline not fading out like everything else (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1027)
 * NaN floats / doubles compare as equal in ProtoFlux and ValueEqualityDriver (but only when not approximate) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1046)
+* Ears and View Overrid(d)en ProtoFlux node names are spelled wrong (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1157)
 * ColorX From HexCode (ProtoFlux node) defaults to Linear profile (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1404)
 * UserInspectors not listing existing users in the session for non-host users (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1964)
 * ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1157

Can only do on the node, but better than nothing :'D