### PR TITLE
Make the ProtoFlux Tool spawn valid float and double quaternion inputs

### DIFF
--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -42,6 +42,7 @@
     "CommunityBugFixCollection.SmoothDraggables.Description": "Umgeht, dass Slider und Joints in Headless-Sessions verrutschen.",
     "CommunityBugFixCollection.TiltedUIAlignment.Description": "Kippt die UI-fokussierte Kamera, um UIX-Renderprobleme zum umgehen.",
     "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Verhindert, dass die Welt-Greifen Fortbewegung den Spieler bei jeder Aktivierung bewegt.",
+    "CommunityBugFixCollection.ValidQuaternionInputs.Description": "Lässt das ProtoFlux-Tool valide float und double Quaternions spawnen.",
     "CommunityBugFixCollection.UserInspectorAsNonHost.Description": "Sorgt dafür, dass Benutzer-Inspektoren bereits präsente Benutzer auch in Sessions anzeigen, in denen man nicht der Host ist."
   }
 }

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -43,6 +43,7 @@
     "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Stops the Grab World Locomotion from moving the player with each activiation.",
     "CommunityBugFixCollection.TiltedUIAlignment.Description": "Tilts the UI-Focus camera to work around UIX rendering issues.",
     "CommunityBugFixCollection.UserInspectorAsNonHost.Description": "Fixes UserInspectors not listing existing users in the session for non-host users.",
+    "CommunityBugFixCollection.ValidQuaternionInputs.Description": "Makes the ProtoFlux Tool spawn valid float and double quaternion inputs.",
     "CommunityBugFixCollection.ValueModDecimal.Description": "Adds a zero check to the Decimal ValueMod ProtoFlux node to prevent DIV/0 crashes"
   }
 }

--- a/CommunityBugFixCollection/ValidQuaternionInputs.cs
+++ b/CommunityBugFixCollection/ValidQuaternionInputs.cs
@@ -1,0 +1,41 @@
+﻿using Elements.Core;
+using FrooxEngine.ProtoFlux;
+using FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes;
+using HarmonyLib;
+using MonkeyLoader;
+using MonkeyLoader.Resonite;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(ValidQuaternionInputs))]
+    [HarmonyPatch(typeof(ProtoFluxTool), nameof(ProtoFluxTool.SpawnNode), [typeof(Type), typeof(Action<ProtoFluxNode>)])]
+    internal sealed class ValidQuaternionInputs : ResoniteMonkey<ValidQuaternionInputs>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        public override bool CanBeDisabled => true;
+
+        private static void Postfix(ProtoFluxNode __result)
+        {
+            if (!Enabled)
+                return;
+
+            Logger.Info(() => $"__result is: {__result.GetType().CompactDescription()}");
+
+            __result.RunInUpdates(0, () =>
+            {
+                if (__result is ValueInput<floatQ> floatQInput)
+                {
+                    floatQInput.Value.Value = floatQ.Identity;
+                    return;
+                }
+
+                if (__result is ValueInput<doubleQ> doubleQInput)
+                    doubleQInput.Value.Value = doubleQ.Identity;
+            });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ just disable them in the settings in the meantime.
 
 * Sliders and Joints snapping in sessions hosted by a headless (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/399)
 * Missing Cloud Home template for Groups (fallback to User Cloud Home) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1144)
+* ProtoFlux inputs for float and double quaternions being spawned with invalid values
+  * https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1158 
+  * https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2979
 * UIX Rendering issues in UI-Focus mode (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1292)
 
 


### PR DESCRIPTION
Adds a workaround for
* https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2979
* https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1158 