### PR TITLE
Add patch for broken SteamVR focus handling

### DIFF
--- a/CommunityBugFixCollection/SteamVrFocusResolutionScale.cs
+++ b/CommunityBugFixCollection/SteamVrFocusResolutionScale.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using MonkeyLoader.Resonite;
+using System.Collections.Generic;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(SteamVrFocusResolutionScale))]
+    [HarmonyPatch("Valve.VR.SteamVR_Render", "OnInputFocus")]
+    internal sealed class SteamVrFocusResolutionScale : ResoniteBugFixMonkey<SteamVrFocusResolutionScale>
+    {
+        public override IEnumerable<string> Authors => Contributors.Goat;
+        
+        private static bool _lastInputFocus = false;
+        
+        public static bool Prefix(bool hasFocus)
+        {
+            // Work around some broken logic in SteamVR focus handling
+            // https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2337#issuecomment-3025681468
+            // https://github.com/ValveSoftware/steamvr_unity_plugin/blob/056c82369d78f253af8cefcae9b289efd69bd960/Assets/SteamVR/Scripts/SteamVR_Render.cs#L237-L262
+            if (_lastInputFocus == hasFocus && !_lastInputFocus)
+            {
+                Logger.Trace(() => "Dropping redundant OnInputFocus call");
+                return false;
+            }
+            
+            _lastInputFocus = hasFocus;
+            return true;
+        }
+    }
+}

--- a/CommunityBugFixCollection/SteamVrFocusResolutionScale.cs
+++ b/CommunityBugFixCollection/SteamVrFocusResolutionScale.cs
@@ -10,6 +10,7 @@ namespace CommunityBugFixCollection
     {
         public override IEnumerable<string> Authors => Contributors.Goat;
         
+        // SteamVR_Render is treated as a singleton in SteamVR and initialized once from SteamVRDriver through SteamVR.Initialize() 
         private static bool _lastInputFocus = false;
         
         public static bool Prefix(bool hasFocus)

--- a/CommunityBugFixCollection/SteamVrFocusResolutionScale.cs
+++ b/CommunityBugFixCollection/SteamVrFocusResolutionScale.cs
@@ -18,7 +18,7 @@ namespace CommunityBugFixCollection
             // Work around some broken logic in SteamVR focus handling
             // https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2337#issuecomment-3025681468
             // https://github.com/ValveSoftware/steamvr_unity_plugin/blob/056c82369d78f253af8cefcae9b289efd69bd960/Assets/SteamVR/Scripts/SteamVR_Render.cs#L237-L262
-            if (_lastInputFocus == hasFocus && !_lastInputFocus)
+            if (Enabled && !hasFocus && !_lastInputFocus)
             {
                 Logger.Trace(() => "Dropping redundant OnInputFocus call");
                 return false;

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ just disable them in the settings in the meantime.
 * FlipAtUser component does not respect view position (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1335)
 * ColorX From HexCode (ProtoFlux node) defaults to Linear profile (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1404)
 * ProtoFlux value casts from byte to other values converting incorrectly (mono / graphical client only) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2257)
+* Resolution scale may get stuck at 0.5 when opening and closing the SteamVR dashboard while the game is hitching (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2337)
 * `ValueMod<Decimal>` node crashes the game when B input is set to zero or disconnected. (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2746)
 * Grid World grid being off-center (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2754)
 * Animators updating all associated fields every frame while enabled but not playing (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3480)


### PR DESCRIPTION
This fixes an issue wherein the resolution scale for SteamVR cameras could become permanently stuck on 0.5f due to broken logic in SteamVR.

I wasn't sure if this really fits into "Resonite Monkeys" but it causes headaches in Resonite since it does tend to hitch a lot, which causes the bug to reproduce, and there isn't a better spot from what I can tell apart from making a separate mod.

> This happens because the SteamVR Unity plugin can sometimes miss events when the game is hitching.
> The resolution is set to 0.5f in [SteamVR_Render.OnInputFocus()](https://github.com/ValveSoftware/steamvr_unity_plugin/blob/056c82369d78f253af8cefcae9b289efd69bd960/Assets/SteamVR/Scripts/SteamVR_Render.cs#L237-L262) as a response to the unfocus event, but when the unfocus event happens twice in a row - as a result of a dropped refocus event - the code stores the already reduced resolution as the current resolution, causing it to never go back to the original resolution once a focus event occurs.
> This is ostensibly a bug in the SteamVR plugin, but it would be trivially fixed by tracking the focus state in SteamVR_Render and not storing the overridden resolution in the field for the actual resolution. The lost events are somewhat troubling but the code that gets events from the OpenVR native looks fine to me, and it seems like this is just expected behavior from OpenVR if your app is unresponsive for multiple seconds.

https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2337