### PR TITLE
Add null-checks in the TrackedDevicePositioner component's UpdateBodyNode method to prevent log spam

### DIFF
--- a/CommunityBugFixCollection/Locale/de.json
+++ b/CommunityBugFixCollection/Locale/de.json
@@ -44,6 +44,7 @@
     "CommunityBugFixCollection.PauseAnimatorUpdates.Description": "Verhindert, dass Animatoren jeden Frame in alle assoziierten Felder schreiben, obwohl sie nicht am animieren sind.",
     "CommunityBugFixCollection.ReallyNoDestroyUndo.Description": "Sorgt dafür, dass die NoDestroyUndo-Komponente tatsächlich verhindert, dass das Zerstören eines Objekts rückgängig gemacht werden kann.",
     "CommunityBugFixCollection.SmoothDraggables.Description": "Umgeht, dass Slider und Joints in Headless-Sessions verrutschen.",
+    "CommunityBugFixCollection.StopTrackedDeviceSpam.Description": "Fügt null-Checks in der UpdateBodyNode-Methode der TrackedDevicePositioner-Komponente hinzu, um Logspam zu verhindern.",
     "CommunityBugFixCollection.TiltedUIAlignment.Description": "Kippt die UI-fokussierte Kamera, um UIX-Renderprobleme zum umgehen.",
     "CommunityBugFixCollection.SteamVRFocusResolutionScale.Description": "Verhindert, dass das SteamVR Unity Plugin die Renderauflösung dauerhaft verringert, wenn ein Fokusevent verpasst wird.",
     "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Verhindert, dass die Welt-Greifen Fortbewegung den Spieler bei jeder Aktivierung bewegt.",

--- a/CommunityBugFixCollection/Locale/en.json
+++ b/CommunityBugFixCollection/Locale/en.json
@@ -52,6 +52,7 @@
     "CommunityBugFixCollection.SmoothDraggables.Description": "Workaround for Sliders and Joints snapping in sessions hosted by a headless.",
     "CommunityBugFixCollection.StationaryGrabWorldActivation.Description": "Stops the Grab World Locomotion from moving the player with each activiation.",
     "CommunityBugFixCollection.SteamVRFocusResolutionScale.Description": "Prevents the SteamVR Unity plugin from permanently lowering the render resolution when a focus event is missed.",
+    "CommunityBugFixCollection.StopTrackedDeviceSpam.Description": "Adds null-checks in the TrackedDevicePositioner component's UpdateBodyNode method to prevent log spam.",
     "CommunityBugFixCollection.TiltedUIAlignment.Description": "Tilts the UI-Focus camera to work around UIX rendering issues.",
     "CommunityBugFixCollection.ValidQuaternionInputs.Description": "Makes the ProtoFlux Tool spawn valid float and double quaternion inputs.",
     "CommunityBugFixCollection.ValueModDecimal.Description": "Adds a zero check to the Decimal ValueMod ProtoFlux node to prevent DIV/0 crashes.",

--- a/CommunityBugFixCollection/StopTrackedDeviceSpam.cs
+++ b/CommunityBugFixCollection/StopTrackedDeviceSpam.cs
@@ -1,0 +1,76 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.CommonAvatar;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CommunityBugFixCollection
+{
+    [HarmonyPatchCategory(nameof(StopTrackedDeviceSpam))]
+    [HarmonyPatch(typeof(TrackedDevicePositioner), nameof(TrackedDevicePositioner.UpdateBodyNode))]
+    internal sealed class StopTrackedDeviceSpam : ResoniteBugFixMonkey<StopTrackedDeviceSpam>
+    {
+        public override IEnumerable<string> Authors => Contributors.Banane9;
+
+        [HarmonyPatch()]
+        private static bool Prefix(TrackedDevicePositioner __instance)
+        {
+            if (!Enabled)
+                return true;
+
+            if (__instance.TrackedDevice is not ITrackedDevice device)
+                return false;
+
+            var bodyNode = device.CorrespondingBodyNode;
+            if (__instance.ObjectSlot.Target is not null && __instance.UsingExternalObjectSlot)
+            {
+                if (__instance.ObjectSlot.Target.Node.Value == bodyNode)
+                    return false;
+
+                __instance.ObjectSlot.Target = null!;
+            }
+
+            var target = __instance.ObjectSlot.Target;
+            if (target is null || target.Node.Value != bodyNode)
+            {
+                var existingBodyNode = __instance.LocalUserRoot.GetRegisteredComponent((AvatarObjectSlot s) => s.Node.Value == bodyNode);
+
+                if (existingBodyNode != null)
+                {
+                    UniLog.Log($"Device corresponding body node: {bodyNode}. Exiting: {__instance.ObjectSlot.Target?.Node.Value}");
+
+                    __instance.RemoveBodyNode();
+                    __instance.ObjectSlot.Target = existingBodyNode;
+
+                    return false;
+                }
+            }
+
+            if (__instance.CreateAvatarObjectSlot.Value)
+                __instance.UpdateObjectSlot();
+
+            if (__instance.BodyNodeRoot.Target.FilterWorldElement() is not null)
+            {
+                if (device.IsDeviceActive)
+                {
+                    __instance.BodyNodeRoot.Target.LocalPosition = device.BodyNodePositionOffset;
+                    __instance.BodyNodeRoot.Target.LocalRotation = device.BodyNodeRotationOffset;
+                }
+                else
+                {
+                    __instance.BodyNodeRoot.Target.LocalPosition = float3.Zero;
+                    __instance.BodyNodeRoot.Target.LocalRotation = floatQ.Identity;
+                }
+            }
+
+            if (__instance.ObjectSlot.Target!.FilterWorldElement() is not null)
+                __instance.ObjectSlot.Target!.Node.Value = bodyNode;
+
+            return false;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ just disable them in the settings in the meantime.
 * DuplicateSlot ProtoFlux node crashes game when if OverrideParent is identical to Template (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/3950)
 * April Fools content is active for users in Universes (commercial usage) (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4016)
 * Instantly removing an AudioOutput component crashes the session (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4286)
+* Log spam from `TrackedDevicePositioner.UpdateBodyNode()` in certain scenarios (https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/5182)
 
 Fixes with no issue (that could be found).
 * Content of notification being off-center.


### PR DESCRIPTION
Adds a fix for https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/5182